### PR TITLE
add types for geolocation callbacks

### DIFF
--- a/src/geolocation.d.ts
+++ b/src/geolocation.d.ts
@@ -1,7 +1,11 @@
 declare module 'geolocation' {
 	type WatchId = number;
-	interface PositionErrorCallback {}
-	interface PositionCallback {}
+	interface PositionErrorCallback {
+		(error: PositionError): void;
+	}
+	interface PositionCallback {
+		(position: Position): void;
+	}
 	interface Geolocation {
 		clearWatch(watchId: WatchId): void;
 		getCurrentPosition(


### PR DESCRIPTION
Adds types for `PositionCallback` and `PositionErrorCallback`, according to the example in the [Geolocation Guide](https://dev.fitbit.com/build/guides/geolocation/#peek-the-current-location).

Fixes #41 