### PR TITLE
Fix file transfer newfile Event

### DIFF
--- a/test-code-samples/companion/file-transfer/receiving-files.ts
+++ b/test-code-samples/companion/file-transfer/receiving-files.ts
@@ -14,7 +14,3 @@ inbox.addEventListener('newfile', processAllFiles);
 
 // Also process any files that arrived when the companion wasn’t running
 processAllFiles();
-
-inbox.onnewfile = event => {
-	console.log(`Received ${event.file.length} bytes as ${event.file.name}`);
-};

--- a/types/companion/file-transfer.d.ts
+++ b/types/companion/file-transfer.d.ts
@@ -33,14 +33,12 @@ declare module 'file-transfer' {
 		json(): Promise<any>;
 		text(): Promise<string>;
 	}
-	interface NewFileEvent extends Event {
-		readonly file: InboxItem;
-	}
+
 	interface Inbox
 		extends EventTarget<{
-			newfile: NewFileEvent;
+			newfile: Event;
 		}> {
-		onnewfile: (event: NewFileEvent) => void;
+		onnewfile: (event: Event) => void;
 		pop(): Promise<InboxItem>;
 	}
 

--- a/types/device/file-transfer.d.ts
+++ b/types/device/file-transfer.d.ts
@@ -32,14 +32,12 @@ declare module 'file-transfer' {
 		json(): Promise<any>;
 		text(): Promise<string>;
 	}
-	interface NewFileEvent extends Event {
-		readonly file: InboxItem;
-	}
+
 	interface Inbox
 		extends EventTarget<{
-			newfile: NewFileEvent;
+			newfile: Event;
 		}> {
-		onnewfile: (event: NewFileEvent) => void;
+		onnewfile: (event: Event) => void;
 		nextFile(name?: string): string | undefined;
 	}
 


### PR DESCRIPTION
It is outdated and based on incorrect documentation. That `NewFileEvent` never existed.