### PR TITLE
Relax 'value' in Storage API to 'any'

### DIFF
--- a/types/companion/storage.d.ts
+++ b/types/companion/storage.d.ts
@@ -1,8 +1,8 @@
 interface Storage {
 	readonly length: number;
 	clear(): void;
-	getItem(key: string): string | null;
+	getItem(key: string): any | null;
 	key(index: number): string | null;
 	removeItem(key: string): void;
-	setItem(key: string, value: string): void;
+	setItem(key: string, value: any): void;
 }


### PR DESCRIPTION
The Fitbit Storage API documentation is to blame for the original code restricting the value type of the Storage to 'string'. However, as I confirmed with a test app, the value can be other than string. At least, AdditiveList accepts and sets an array as value. I think it's best just relax it to 'any'.