### PR TITLE
Makes settings typed with https://github.com/bingtimren/fitbit-settings-commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
 		"eslint-config-prettier": "^6.11.0",
 		"prettier": "^2.0.5",
 		"typescript": "^3.9.7"
-	}
+	},
+	"dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,5 @@
 		"eslint-config-prettier": "^6.11.0",
 		"prettier": "^2.0.5",
 		"typescript": "^3.9.7"
-	},
-	"dependencies": {}
+	}
 }

--- a/test-code-samples/settings/additive-list.tsx
+++ b/test-code-samples/settings/additive-list.tsx
@@ -152,3 +152,116 @@ type Option = {
 		/>
 	}
 />;
+
+// typed settings examples
+interface AdditiveOption { name:string, value:{
+	location: string,
+	icon: string,
+} }
+interface AdditiveListSettingsType {
+	validKey: AdditiveOption[],
+	assignableKey: {name:string}[],
+	invalidKey: string
+}
+
+<AdditiveList<AdditiveOption>
+	title="A list of TextImageRow"
+	settingsKey="select-list"
+	maxItems="5"
+	renderItem={({ name, value }) => (
+		<TextImageRow label={name} sublabel={value.location} icon={value.icon} />
+	)}
+	addAction={
+		<Select
+			label="Add Item"
+			options={[
+				{
+					name: 'Label1',
+					required: true,
+					value: {
+						location: 'Sub-Label',
+						icon: 'https://tinyurl.com/ybbmpxxq',
+					},
+				},
+			]}
+		/>
+	}
+/>;
+
+<AdditiveList<AdditiveOption, AdditiveListSettingsType>
+	title="A list of TextImageRow"
+	settingsKey="validKey"
+	maxItems="5"
+	renderItem={({ name, value }) => (
+		<TextImageRow label={name} sublabel={value.location} icon={value.icon} />
+	)}
+	addAction={
+		<Select
+			label="Add Item"
+			options={[
+				{
+					name: 'Label1',
+					required: true,
+					value: {
+						location: 'Sub-Label',
+						icon: 'https://tinyurl.com/ybbmpxxq',
+					},
+				},
+			]}
+		/>
+	}
+/>;
+
+<AdditiveList<AdditiveOption, AdditiveListSettingsType>
+	title="A list of TextImageRow"
+	settingsKey="assignableKey"
+	maxItems="5"
+	renderItem={({ name, value }) => (
+		<TextImageRow label={name} sublabel={value.location} icon={value.icon} />
+	)}
+	addAction={
+		<Select
+			label="Add Item"
+			options={[
+				{
+					name: 'Label1',
+					required: true,
+					value: {
+						location: 'Sub-Label',
+						icon: 'https://tinyurl.com/ybbmpxxq',
+					},
+				},
+			]}
+		/>
+	}
+/>;
+
+/*
+
+// should not and do not work
+
+<AdditiveList<AdditiveOption, AdditiveListSettingsType>
+	title="A list of TextImageRow"
+	settingsKey="invalidKey"
+	maxItems="5"
+	renderItem={({ name, value }) => (
+		<TextImageRow label={name} sublabel={value.location} icon={value.icon} />
+	)}
+	addAction={
+		<Select
+			label="Add Item"
+			options={[
+				{
+					name: 'Label1',
+					required: true,
+					value: {
+						location: 'Sub-Label',
+						icon: 'https://tinyurl.com/ybbmpxxq',
+					},
+				},
+			]}
+		/>
+	}
+/>;
+
+*/

--- a/test-code-samples/settings/color-select.tsx
+++ b/test-code-samples/settings/color-select.tsx
@@ -26,3 +26,74 @@
 		console.log(`value: ${value.align}, number: ${value.number}`);
 	}}
 />;
+
+// Work with typed settings
+interface ColorValue { align: string, number: string}
+
+interface ColorSelectSettingsType {
+	validKey : ColorValue
+	anyKey: any
+	assignableKey : { align: string, number: string, option?:boolean }
+	incompatibleKey : string
+}
+
+<ColorSelect<ColorValue, ColorSelectSettingsType>
+	settingsKey="validKey"
+	colors={[
+		{ color: 'tomato', value: { align: 'left', number: '1' } },
+		{ color: 'sandybrown', value: { align: 'right', number: '2' } },
+	]}
+	onSelection={(value) => {
+		console.log(`value: ${value.align}, number: ${value.number}`);
+	}}
+/>;
+
+<ColorSelect<ColorValue, ColorSelectSettingsType>
+	settingsKey="anyKey"
+	colors={[
+		{ color: 'tomato', value: { align: 'left', number: '1' } },
+		{ color: 'sandybrown', value: { align: 'right', number: '2' } },
+	]}
+	onSelection={(value) => {
+		console.log(`value: ${value.align}, number: ${value.number}`);
+	}}
+/>;
+
+<ColorSelect<ColorValue, ColorSelectSettingsType>
+	settingsKey="assignableKey"
+	colors={[
+		{ color: 'tomato', value: { align: 'left', number: '1' } },
+		{ color: 'sandybrown', value: { align: 'right', number: '2' } },
+	]}
+	onSelection={(value) => {
+		console.log(`value: ${value.align}, number: ${value.number}`);
+	}}
+/>;
+
+/*
+
+// examples should not and do not work
+
+<ColorSelect<ColorValue, ColorSelectSettingsType>
+	settingsKey="whatever"
+	colors={[
+		{ color: 'tomato', value: { align: 'left', number: '1' } },
+		{ color: 'sandybrown', value: { align: 'right', number: '2' } },
+	]}
+	onSelection={(value) => {
+		console.log(`value: ${value.align}, number: ${value.number}`);
+	}}
+/>;
+
+<ColorSelect<ColorValue, ColorSelectSettingsType>
+	settingsKey="incompatibleKey"
+	colors={[
+		{ color: 'tomato', value: { align: 'left', number: '1' } },
+		{ color: 'sandybrown', value: { align: 'right', number: '2' } },
+	]}
+	onSelection={(value) => {
+		console.log(`value: ${value.align}, number: ${value.number}`);
+	}}
+/>;
+
+*/

--- a/test-code-samples/settings/image-picker.tsx
+++ b/test-code-samples/settings/image-picker.tsx
@@ -21,3 +21,46 @@ declare const doSomethingWithImage;
 		doSomethingWithImage(image, imageSize)
 	}
 />;
+
+// with typed settings
+interface ImagePickerSettingsType {
+	validKey : {
+		imageUri:string,
+		imageSize: {
+			width:number,
+			height:number
+		}
+	},
+	assignableKey : {
+		imageUri:string,
+		imageSize: {
+			width:number,
+		},
+		somethingElse?:string
+	}, 
+	otherKey: 'something-else'
+}
+
+<ImagePicker<ImagePickerSettingsType>
+	settingsKey="validKey"
+	imageWidth="300"
+	imageHeight="300"
+/>;
+
+<ImagePicker<ImagePickerSettingsType>
+	settingsKey="assignableKey"
+	imageWidth="300"
+	imageHeight="300"
+/>;
+
+/*
+
+// should not and do not work
+
+<ImagePicker<ImagePickerSettingsType>
+	settingsKey="otherKey"
+	imageWidth="300"
+	imageHeight="300"
+/>;
+
+*/

--- a/test-code-samples/settings/select.tsx
+++ b/test-code-samples/settings/select.tsx
@@ -33,3 +33,127 @@
 	)}
 	onSelection={(selection) => console.log(selection)}
 />;
+
+// typed examples
+
+interface SelectOption {name:string, value:string}
+
+interface SelectSettingsType {
+	selectProp : {
+		values:SelectOption[],
+		selected:number[]
+	}
+	compatibleProp : {
+		values:SelectOption[],
+		selected:number[],
+		other?: string
+	}
+	incompatibleProp : {
+		values:{name:string, value:string, option:boolean}[],
+		selected:number[],
+		other: string
+	}
+	compatibleProp2 : {
+		values:{name:string}[],
+		selected:number[],
+		other?: string
+	},
+}
+
+<Select<SelectOption, SelectSettingsType>
+	label={`Multi-Selection`}
+	multiple
+	settingsKey="selectProp"
+	options={[
+		{ name: 'One', value: '1' },
+		{ name: 'Two', value: '2' },
+	]}
+	renderItem={(option) => (
+		<TextImageRow
+			label={option.name}
+			sublabel="Sub-Label"
+			icon="https://tinyurl.com/ybbmpxxq"
+		/>
+	)}
+	onSelection={(selection) => console.log(selection)}
+/>;
+
+<Select<SelectOption, SelectSettingsType>
+	label={`Multi-Selection`}
+	multiple
+	settingsKey="compatibleProp"
+	options={[
+		{ name: 'One', value: '1' },
+		{ name: 'Two', value: '2' },
+	]}
+	renderItem={(option) => (
+		<TextImageRow
+			label={option.name}
+			sublabel="Sub-Label"
+			icon="https://tinyurl.com/ybbmpxxq"
+		/>
+	)}
+	onSelection={(selection) => console.log(selection)}
+/>;
+
+<Select<SelectOption, SelectSettingsType>
+	label={`Multi-Selection`}
+	multiple
+	settingsKey="compatibleProp2"
+	options={[
+		{ name: 'One', value: '1' },
+		{ name: 'Two', value: '2' },
+	]}
+	renderItem={(option) => (
+		<TextImageRow
+			label={option.name}
+			sublabel="Sub-Label"
+			icon="https://tinyurl.com/ybbmpxxq"
+		/>
+	)}
+	onSelection={(selection) => console.log(selection)}
+/>;
+
+
+/*
+
+// examples should not and do not work
+
+
+<Select<SelectOption, SelectSettingsType>
+	label={`Multi-Selection`}
+	multiple
+	settingsKey="incompatibleProp"
+	options={[
+		{ name: 'One', value: '1' },
+		{ name: 'Two', value: '2' },
+	]}
+	renderItem={(option) => (
+		<TextImageRow
+			label={option.name}
+			sublabel="Sub-Label"
+			icon="https://tinyurl.com/ybbmpxxq"
+		/>
+	)}
+	onSelection={(selection) => console.log(selection)}
+/>;
+
+<Select<SelectOption, SelectSettingsType>
+	label={`Multi-Selection`}
+	multiple
+	settingsKey="anyKey"
+	options={[
+		{ name: 'One', value: '1' },
+		{ name: 'Two', value: '2' },
+	]}
+	renderItem={(option) => (
+		<TextImageRow
+			label={option.name}
+			sublabel="Sub-Label"
+			icon="https://tinyurl.com/ybbmpxxq"
+		/>
+	)}
+	onSelection={(selection) => console.log(selection)}
+/>;
+
+*/

--- a/test-code-samples/settings/slider.tsx
+++ b/test-code-samples/settings/slider.tsx
@@ -1,1 +1,41 @@
 <Slider label="Example" settingsKey="slider" min="0" max="60" />;
+
+// Work with typed settings
+
+interface SliderSettingsType {
+	stringKey : string,
+    booleanKey : boolean,
+    numberKey : number,
+    assignableKey: number | undefined,
+}
+
+<Slider<SliderSettingsType>
+    label="Example" 
+    settingsKey="numberKey" 
+    min="0" 
+    max="60" />;
+
+<Slider<SliderSettingsType>
+    label="Example" 
+    settingsKey="assignableKey" 
+    min="0" 
+    max="60" />;
+
+/*
+
+// examples should not, and do not, work
+<Slider<SliderSettingsType>
+    label="Example" 
+    settingsKey="slider" 
+    min="0" 
+    max="60" />;
+
+<Slider<SliderSettingsType>
+    label="Example" 
+    settingsKey="stringKey" 
+    min="0" 
+    max="60" />;
+
+
+
+*/

--- a/test-code-samples/settings/text-input.tsx
+++ b/test-code-samples/settings/text-input.tsx
@@ -31,3 +31,91 @@
 <TextInput type="email" value="email value" />;
 <TextInput type="tel" value="tel value" />;
 <TextInput type="url" value="url value" />;
+
+// Work with typed settings
+interface TextInputOption {
+	name:string, value?:string
+}
+interface TextInputSettingsType {
+	validKey : TextInputOption,
+	otherKey : {name:string, value:string},
+	assignableKey : {name:string},
+	stringKey: string
+}
+
+<TextInput<TextInputOption>
+	title="Add List Item"
+	label="Item Name"
+	placeholder="Type something"
+	action="Add Item"
+	settingsKey="anything"
+	onAutocomplete={(value) => {
+		const autoValues = [
+			{ name: 'red', value: '1' },
+		];
+		return autoValues.filter((option) => option.name.indexOf(value) === 0);
+	}}
+/>;
+
+<TextInput<TextInputOption, TextInputSettingsType>
+	title="Add List Item"
+	label="Item Name"
+	placeholder="Type something"
+	action="Add Item"
+	settingsKey="validKey"
+	onAutocomplete={(value) => {
+		const autoValues = [
+			{ name: 'red', value: '1' },
+		];
+		return autoValues.filter((option) => option.name.indexOf(value) === 0);
+	}}
+/>;
+
+<TextInput<TextInputOption, TextInputSettingsType>
+	title="Add List Item"
+	label="Item Name"
+	placeholder="Type something"
+	action="Add Item"
+	settingsKey="assignableKey"
+	onAutocomplete={(value) => {
+		const autoValues = [
+			{ name: 'red', value: '1' },
+		];
+		return autoValues.filter((option) => option.name.indexOf(value) === 0);
+	}}
+/>;
+
+// use simple value, i.e. string
+<TextInput<string, TextInputSettingsType>
+	title="Add List Item"
+	label="Item Name"
+	placeholder="Type something"
+	action="Add Item"
+	settingsKey="stringKey"
+	useSimpleValue={true}
+/>;
+
+/*
+// examples should not, and do not work
+
+<TextInput<TextInputOption, TextInputSettingsType>
+	title="Add List Item"
+	label="Item Name"
+	placeholder="Type something"
+	action="Add Item"
+	settingsKey="otherKey"
+	onAutocomplete={(value) => {
+		const autoValues = [
+			{ name: 'red', value: '1' },
+			{ name: 'orange', value: '2' },
+			{ name: 'yellow', value: '3' },
+			{ name: 'green', value: '4' },
+			{ name: 'blue', value: '5' },
+			{ name: 'purple', value: '6' },
+		];
+		return autoValues.filter((option) => option.name.indexOf(value) === 0);
+	}}
+/>;
+
+
+ */

--- a/test-code-samples/settings/toggle.tsx
+++ b/test-code-samples/settings/toggle.tsx
@@ -12,3 +12,33 @@ declare const settings: any;
 		<Toggle settingsKey="hiddenToggle" />
 	);
 }
+
+// Work with typed settings
+
+interface ToggleSettingsType {
+	stringKey : string,
+	booleanKey : boolean,
+	assignableKey : boolean | string
+}
+
+<Toggle<ToggleSettingsType>
+	settingsKey="booleanKey"
+></Toggle>;
+
+<Toggle<ToggleSettingsType>
+	settingsKey="assignableKey"
+></Toggle>;
+
+/*
+
+// examples should not work
+
+<Toggle<ToggleSettingsType>
+	settingsKey="any other key should report an error"
+></Toggle>;
+
+<Toggle<ToggleSettingsType>
+	settingsKey="stringKey"
+></Toggle>;
+
+ */

--- a/types/settings/components.d.ts
+++ b/types/settings/components.d.ts
@@ -25,20 +25,24 @@ declare const Button: (props: {
 	list?: boolean;
 	onClick: (event: Event) => void;
 }) => JSX.Element;
-declare const Toggle: (props: {
-	settingsKey: string;
+declare const Toggle: <SettingsType extends object>(props: {
+	settingsKey: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, boolean> 
+		: string);
 	label?: JSX.Element;
 	onChange?: (newValue: boolean) => void;
 }) => JSX.Element;
-declare const Slider: (props: {
+declare const Slider: <SettingsType extends object>(props: {
 	label?: JSX.Element;
-	settingsKey?: string;
+	settingsKey: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, number> 
+		: string);
 	min: number | string;
 	max: number | string;
 	step?: number | string;
 	onChange?: (newValue: number) => void;
 }) => JSX.Element;
-declare const TextInput: <Option extends { name: string }>(props: {
+declare const TextInput: <Option extends { name: string }|string, SettingsType extends object = any>(props: {
 	title?: string;
 	label?: string;
 	placeholder?: string;
@@ -46,7 +50,9 @@ declare const TextInput: <Option extends { name: string }>(props: {
 	type?: string;
 	value?: string;
 	disabled?: boolean;
-	settingsKey?: string;
+	settingsKey?: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, Option>  // when autocomplete, an Option type can be preserved under the key
+		: string);
 	useSimpleValue?: boolean;
 	onChange?: (newValue: string) => void;
 	onAutocomplete?: (newValue: string) => ReadonlyArray<Option>;
@@ -56,18 +62,25 @@ declare const TextInput: <Option extends { name: string }>(props: {
 		newValue: string,
 	) => JSX.Element;
 }) => JSX.Element;
-declare const ColorSelect: <Value = string>(props: {
+declare const ColorSelect: <Value = string, SettingsType extends object = any>(props: {
 	colors: ReadonlyArray<{ color: string; value?: Value }>;
 	centered?: boolean;
-	settingsKey?: string;
+	settingsKey?: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, Value> 
+		: string);
 	value?: Value;
 	onSelection?: (value: Value) => void;
 }) => JSX.Element;
-declare const Select: <Option extends { name: string }>(props: {
+declare const Select: <Option extends { name: string }, SettingsType extends object = any>(props: {
 	title?: string;
 	selectViewTitle?: string;
 	label?: string;
-	settingsKey?: string;
+	settingsKey?: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, {
+			values:Option[],
+			selected:number[]
+		}> 
+		: string);
 	options: ReadonlyArray<Option>;
 	multiple?: boolean;
 	disabled?: boolean;
@@ -78,12 +91,14 @@ declare const Select: <Option extends { name: string }>(props: {
 	}) => void;
 }) => JSX.Element;
 declare const AdditiveList: <Option extends {
-	[k: string]: any;
-	name: string;
-}>(props: {
+		[k: string]: any;
+		name: string;
+	}, SettingsType extends object = any>(props: {
 	title?: string;
 	description?: string;
-	settingsKey?: string;
+	settingsKey?: (SettingsType extends object 
+		? keyof PickByExtendsValue<SettingsType, Option[]> 
+		: string);
 	minItems?: number | string;
 	maxItems?: number | string;
 	renderItem?: (item: Option) => JSX.Element;
@@ -124,7 +139,14 @@ declare const StravaLogin: (props: {
 	clientSecret?: string;
 	onAccessToken?: (accessToken: string, userInfo: any) => void;
 }) => JSX.Element;
-declare const ImagePicker: (props: {
+
+declare const ImagePicker: <SettingsType extends object = any, ImagePickResult = {
+	imageUri:string,
+	imageSize: {
+		width:number,
+		height:number
+	}
+}>(props: {
 	title?: string;
 	description?: string;
 	label?: string;
@@ -132,7 +154,9 @@ declare const ImagePicker: (props: {
 	pickerTitle?: string;
 	pickerImageTitle?: string;
 	pickerLabel?: string;
-	settingsKey?: string;
+	settingsKey?: SettingsType extends object
+		? keyof PickByExtendsValue<SettingsType, ImagePickResult>
+		: string;
 	imageWidth?: number | string;
 	imageHeight?: number | string;
 	showIcon?: boolean;

--- a/types/settings/components.d.ts
+++ b/types/settings/components.d.ts
@@ -27,7 +27,7 @@ declare const Button: (props: {
 }) => JSX.Element;
 declare const Toggle: <SettingsType extends object>(props: {
 	settingsKey: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, boolean> 
+		? PickKeyByExtendsValue<SettingsType, boolean> 
 		: string);
 	label?: JSX.Element;
 	onChange?: (newValue: boolean) => void;
@@ -35,7 +35,7 @@ declare const Toggle: <SettingsType extends object>(props: {
 declare const Slider: <SettingsType extends object>(props: {
 	label?: JSX.Element;
 	settingsKey: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, number> 
+		? PickKeyByExtendsValue<SettingsType, number> 
 		: string);
 	min: number | string;
 	max: number | string;
@@ -51,7 +51,7 @@ declare const TextInput: <Option extends { name: string }|string, SettingsType e
 	value?: string;
 	disabled?: boolean;
 	settingsKey?: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, Option>  // when autocomplete, an Option type can be preserved under the key
+		? PickKeyByExtendsValue<SettingsType, Option>  // when autocomplete, an Option type can be preserved under the key
 		: string);
 	useSimpleValue?: boolean;
 	onChange?: (newValue: string) => void;
@@ -66,7 +66,7 @@ declare const ColorSelect: <Value = string, SettingsType extends object = any>(p
 	colors: ReadonlyArray<{ color: string; value?: Value }>;
 	centered?: boolean;
 	settingsKey?: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, Value> 
+		? PickKeyByExtendsValue<SettingsType, Value> 
 		: string);
 	value?: Value;
 	onSelection?: (value: Value) => void;
@@ -76,7 +76,7 @@ declare const Select: <Option extends { name: string }, SettingsType extends obj
 	selectViewTitle?: string;
 	label?: string;
 	settingsKey?: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, {
+		? PickKeyByExtendsValue<SettingsType, {
 			values:Option[],
 			selected:number[]
 		}> 
@@ -97,7 +97,7 @@ declare const AdditiveList: <Option extends {
 	title?: string;
 	description?: string;
 	settingsKey?: (SettingsType extends object 
-		? keyof PickByExtendsValue<SettingsType, Option[]> 
+		? PickKeyByExtendsValue<SettingsType, Option[]> 
 		: string);
 	minItems?: number | string;
 	maxItems?: number | string;
@@ -155,7 +155,7 @@ declare const ImagePicker: <SettingsType extends object = any, ImagePickResult =
 	pickerImageTitle?: string;
 	pickerLabel?: string;
 	settingsKey?: SettingsType extends object
-		? keyof PickByExtendsValue<SettingsType, ImagePickResult>
+		? PickKeyByExtendsValue<SettingsType, ImagePickResult>
 		: string;
 	imageWidth?: number | string;
 	imageHeight?: number | string;

--- a/types/settings/index.d.ts
+++ b/types/settings/index.d.ts
@@ -8,3 +8,4 @@
 /// <reference path="../shared/i18n.d.ts" />
 /// <reference path="./components.d.ts" />
 /// <reference path="./jsx.d.ts" />
+/// <reference path="./utility-types.d.ts" />

--- a/types/settings/utility-types.d.ts
+++ b/types/settings/utility-types.d.ts
@@ -1,3 +1,4 @@
-type PickByExtendsValue<T, ValueType> = Pick<T, {
+type PickKeyByExtendsValue<T, ValueType> = {
     [Key in keyof T]-?: ValueType extends T[Key] ? Key : never;
-}[keyof T]>;
+}[keyof T];
+

--- a/types/settings/utility-types.d.ts
+++ b/types/settings/utility-types.d.ts
@@ -1,0 +1,3 @@
+type PickByExtendsValue<T, ValueType> = Pick<T, {
+    [Key in keyof T]-?: ValueType extends T[Key] ? Key : never;
+}[keyof T]>;


### PR DESCRIPTION
Hi,

I like to work with things typed, to allow compiler find issues, to allow editors autocomplete and highlight errors. So it's a real pleasure using fitbit-sdk-types.

However the settings API preserve everything in strings under string keys. When settings become complex, without typing becomes a real headache. Hence I wrote a wrapper to provide typing to the settings, and also pack / unpack the values befind the scene. No more working with string keys, no more calling JSON.stringify and JSON.parse. It's all done for you.

See [](https://github.com/bingtimren/fitbit-settings-commons) for details. This package has been tested and actually used in a project of mine.

Then, when working with setting components, I wish to extend the typing checks to the `settingsKey` property of the components, and the types of the properties in the setting types.

For example, when using a <Select> component, what is put under `settingsKey` is something like `{selected: Array, values: Array}`. I wish to make sure that the value of the `settingsKey` actually points to a property of the settings type that has the type `{selected: Array, values: Array}`.

I have achieved this in my fork, with proper test cases added. When not working with my package fitbit-settings-commons, my change has no effect to the normal use.

I'm not sure if you are willing to accept this pull request, as its purpose is to add support to work with my package. I'm happy to publish my fork under my namespace, if you are reluctant to merge this pull request. 

If you are willing to merge this pull-request but wish to add something to the README, I will do that.

Thanks.

Bing