### PR TITLE
Adds missing Select.selected property

### DIFF
--- a/types/settings/components.d.ts
+++ b/types/settings/components.d.ts
@@ -71,6 +71,7 @@ declare const Select: <Option extends { name: string }>(props: {
 	options: ReadonlyArray<Option>;
 	multiple?: boolean;
 	disabled?: boolean;
+	selected?: ReadonlyArray<number>;
 	renderItem?: (option: Option) => JSX.Element;
 	onSelection?: (selection: {
 		selected: ReadonlyArray<number>;


### PR DESCRIPTION
Without it, you can't customize the data a `Select` saves, e.g. https://github.com/eamodio/fitbit-pure/blob/1f7b877e560576c93e6bf6d4aaba870f079df766/settings/index.tsx#L148-L157

See https://dev.fitbit.com/build/reference/settings-api/#select

While the property is not properly listed in the _Properties_ section, it is mentioned in the note below them.

> Alternatively, you may manually manage the value of the <Select> via the onSelection event and *selected* property.