### PR TITLE
Add getElementsByTypeName()

### DIFF
--- a/types/device/document/elements.d.ts
+++ b/types/device/document/elements.d.ts
@@ -17,6 +17,7 @@ interface ElementSearch {
 	getElementsByTagName<TagName extends keyof ElementSearchMap>(
 		tagName: TagName,
 	): Array<ElementSearchMap[TagName]>;
+	getElementsByTypeName(typeName: string): Element[];
 }
 type EventName =
 	| 'activate'


### PR DESCRIPTION
getElementsByTypeName() does exist. [Reference](https://dev.fitbit.com/build/reference/device-api/document/).

It might be tempting to implement this by restricting the argument to a list of predefined types (of which, I think, there is only one at the moment). However, it's possible to specify arbitrary type names (as we can for ids and classes), and this is useful for widget management. I suspect Fitbit uses the typeattribute in a similar way: see [dynamic-textarea](https://dev.fitbit.com/build/guides/user-interface/svg/#dynamic-textarea).