### PR TITLE
Remove settingsKey from Text

### DIFF
--- a/types/settings/components.d.ts
+++ b/types/settings/components.d.ts
@@ -13,7 +13,6 @@ declare const Text: (props: {
 	bold?: boolean;
 	italic?: boolean;
 	align?: 'left' | 'center' | 'right';
-	settingsKey?: string;
 	children: JSX.Element;
 }) => JSX.Element;
 declare const TextImageRow: (props: {


### PR DESCRIPTION
Just noticed that the settingsKey wasn't doing anything cuz in the content of `<Text>` there is the value 

`<Text>{props.settings.[NAME]}</Text>`

I'm sorry, I should've notice it but it was kinda hidden in the description of a section